### PR TITLE
config: masterIssue -> dependencyDashboard

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,7 +18,7 @@
   ],
   "prCreation": "not-pending",
   "rebaseWhen": "behind-base-branch",
-  "masterIssue": true,
+  "dependencyDashboard": true,
   "stabilityDays": 3,
   "prNotPendingHours": 96,
   "lockFileMaintenance": {


### PR DESCRIPTION
Renovate no longer uses the term `masterIssue`, this term is replaced by the term `dependencyDashboard`.