### PR TITLE
chore: add labels to all renovate pr

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,18 +1,21 @@
 {
   "extends": ["config:js-lib", "schedule:earlyMondays"],
+  "labels": ["renovate"],
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor", "major"],
       "automergeType": "branch",
       "automerge": true,
-      "semanticCommitScope": "dev-deps"
+      "semanticCommitScope": "dev-deps",
+      "addLabels": ["deps: dev"]
     },
     {
       "matchDepTypes": ["dependencies"],
       "automergeType": "branch",
       "matchUpdateTypes": ["patch"],
       "semanticCommitType": "deps",
+      "addLabels": ["deps"],
       "automerge": true
     }
   ],


### PR DESCRIPTION
This PR uses the `labels` and `addLabel` configuration options to add a `renovate` label to all PRs and add a `deps` or `deps: dev` to dependency update PRs.